### PR TITLE
fix: use relative API paths

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,20 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  async rewrites() {
+    const backend = process.env.API_PROXY_TARGET || 'http://localhost:4000'
+    const minio = process.env.MINIO_PROXY_TARGET || 'http://localhost:9000'
+    const strip = (u) => u.replace(/\/$/, '')
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${strip(backend)}/:path*`,
+      },
+      {
+        source: '/files/:bucket/:path*',
+        destination: `${strip(minio)}/:bucket/:path*`,
+      },
+    ]
+  },
 }
 module.exports = nextConfig

--- a/frontend/pages/admin.tsx
+++ b/frontend/pages/admin.tsx
@@ -1,7 +1,8 @@
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 
-const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:4000';
+// По умолчанию используем относительное API через gateway
+const API = process.env.NEXT_PUBLIC_API_BASE || '/api';
 
 export default function Admin() {
   const [videos, setVideos] = useState<any[]>([]);

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -2,7 +2,9 @@ import axios from 'axios';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 
-const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:4000';
+// По умолчанию обращаемся к проксированному API
+// на том же домене (gateway -> /api).
+const API = process.env.NEXT_PUBLIC_API_BASE || '/api';
 
 export default function Home() {
   const [videos, setVideos] = useState<any[]>([]);
@@ -29,7 +31,7 @@ export default function Home() {
           <div key={v.id} className="bg-white rounded-xl p-3 shadow">
             <Link href={`/video/${v.id}`}>
               <a>
-                <img src={v.thumbnail || '/placeholder.png'} className="w-full rounded-lg object-cover h-48" />
+                <img src={v.thumbnail_url || '/placeholder.png'} className="w-full rounded-lg object-cover h-48" />
                 <div className="mt-2">
                   <div className="font-semibold">{v.title}</div>
                   <div className="text-sm text-gray-500">{v.author_name}</div>

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,7 +1,8 @@
 import axios from 'axios';
 import { useState } from 'react';
 
-const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:4000';
+// Используем /api по умолчанию, чтобы фронтенд работал через gateway
+const API = process.env.NEXT_PUBLIC_API_BASE || '/api';
 
 export default function Login() {
   const [email, setEmail] = useState('');

--- a/frontend/pages/register.tsx
+++ b/frontend/pages/register.tsx
@@ -1,7 +1,8 @@
 import axios from 'axios';
 import { useState } from 'react';
 
-const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:4000';
+// По умолчанию используем /api (gateway)
+const API = process.env.NEXT_PUBLIC_API_BASE || '/api';
 
 export default function Register() {
   const [email, setEmail] = useState('');

--- a/frontend/pages/upload.tsx
+++ b/frontend/pages/upload.tsx
@@ -1,7 +1,8 @@
 import axios from 'axios';
 import { useState } from 'react';
 
-const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:4000';
+// API по умолчанию – относительный путь, чтобы работать за gateway
+const API = process.env.NEXT_PUBLIC_API_BASE || '/api';
 
 export default function Upload() {
   const [title, setTitle] = useState('');

--- a/frontend/pages/video/[id].tsx
+++ b/frontend/pages/video/[id].tsx
@@ -2,7 +2,8 @@ import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 
-const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:4000';
+// Используем относительный путь к API (gateway проксирует /api)
+const API = process.env.NEXT_PUBLIC_API_BASE || '/api';
 
 export default function VideoPage() {
   const router = useRouter();
@@ -40,7 +41,7 @@ export default function VideoPage() {
     <main className='max-w-3xl mx-auto p-6'>
       <h1 className='text-2xl font-bold mb-4'>{video.title}</h1>
       <div className='mb-4'>
-        <video src={video.video_url} controls className='w-full rounded-lg' poster={video.thumbnail || undefined} />
+        <video src={video.video_url} controls className='w-full rounded-lg' poster={video.thumbnail_url || undefined} />
       </div>
       <p className='text-gray-700 mb-2'>{video.description}</p>
       <div className='mb-4'>


### PR DESCRIPTION
## Summary
- default to `/api` when building frontend API URLs
- read `thumbnail_url` returned from backend
- proxy `/api` and `/files` requests to backend and MinIO during development

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: required TypeScript dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ab56807d8883209c1b529e5ab2b70f