### PR TITLE
Fix Reels page video/thumbnail loading

### DIFF
--- a/frontend/pages/reels.tsx
+++ b/frontend/pages/reels.tsx
@@ -1,7 +1,10 @@
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 
-const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:4000';
+// По умолчанию используем проксированный путь '/api', который
+// обрабатывается gateway. Это позволяет получать корректные ссылки
+// на файлы и видео, а также избегать прямых обращений к backend.
+const API = process.env.NEXT_PUBLIC_API_BASE || '/api';
 
 export default function ReelsPage() {
   const [videos, setVideos] = useState<any[]>([]);
@@ -14,7 +17,15 @@ export default function ReelsPage() {
     <main className="h-screen snap-y snap-mandatory overflow-y-scroll">
       {videos.map(v => (
         <section key={v.id} className="snap-start h-screen w-screen relative flex items-center justify-center bg-black">
-          <video src={v.video_url} poster={v.thumbnail || undefined} controls={false} autoPlay muted loop className="absolute inset-0 w-full h-full object-cover" />
+          <video
+            src={v.video_url}
+            poster={v.thumbnail_url || undefined}
+            controls={false}
+            autoPlay
+            muted
+            loop
+            className="absolute inset-0 w-full h-full object-cover"
+          />
           <div className="absolute bottom-6 left-4 text-white">
             <div className="font-semibold">{v.title}</div>
             <div className="text-sm opacity-80">{v.author_name}</div>


### PR DESCRIPTION
## Summary
- use gateway proxied API path on Reels feed
- render thumbnails via `thumbnail_url` in video tag

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab5f344ee08320849764e966a8932f