### PR TITLE
fix: correct React structure on reels page

### DIFF
--- a/frontend/pages/reels.tsx
+++ b/frontend/pages/reels.tsx
@@ -5,6 +5,16 @@ const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:4000';
 
 export default function ReelsPage() {
   const [videos, setVideos] = useState<any[]>([]);
+
+  useEffect(() => {
+    axios.get(`${API}/videos`).then(r => setVideos(r.data)).catch(console.error);
+  }, []);
+
+  return (
+    <main className="snap-y snap-mandatory h-screen overflow-y-scroll">
+      {videos.map(v => (
+        <section key={v.id} className="relative w-full h-screen snap-start">
+          <video src={v.video_url} className="w-full h-full object-cover" controls />
           <div className="absolute bottom-6 left-4 text-white">
             <div className="font-semibold">{v.title}</div>
             <div className="text-sm opacity-80">{v.author_name}</div>


### PR DESCRIPTION
## Summary
- wrap Reels page JSX in a parent element so Next.js can build

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab5fc46d38832084d46c1e13b9459b