### PR TITLE
fix: correct React structure on reels page

### DIFF
--- a/frontend/pages/reels.tsx
+++ b/frontend/pages/reels.tsx
@@ -5,6 +5,24 @@ const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:4000';
 
 export default function ReelsPage() {
   const [videos, setVideos] = useState<any[]>([]);
+
+  useEffect(() => {
+    axios.get(`${API}/videos`).then(r => setVideos(r.data)).catch(console.error);
+  }, []);
+
+  return (
+    <main className="h-screen snap-y snap-mandatory overflow-y-scroll">
+      {videos.map(v => (
+        <section key={v.id} className="snap-start h-screen w-screen relative flex items-center justify-center bg-black">
+          <video
+            src={v.video_url}
+            poster={v.thumbnail || undefined}
+            controls={false}
+            autoPlay
+            muted
+            loop
+            className="absolute inset-0 w-full h-full object-cover"
+          />
           <div className="absolute bottom-6 left-4 text-white">
             <div className="font-semibold">{v.title}</div>
             <div className="text-sm opacity-80">{v.author_name}</div>


### PR DESCRIPTION
## Summary
- wrap Reels page JSX in a parent element so Next.js can build
- sync Reels page with latest main to avoid merge conflicts

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab5fc46d38832084d46c1e13b9459b