### PR TITLE
Add logging for video requests

### DIFF
--- a/backend/src/controllers/video.controller.ts
+++ b/backend/src/controllers/video.controller.ts
@@ -78,6 +78,7 @@ export async function uploadVideo(req: Request, res: Response) {
 // список видео
 export async function listVideos(req: Request, res: Response) {
   try {
+    console.log("[%s] GET /videos", new Date().toISOString());
     const bucket = process.env.S3_BUCKET!;
     const videos = (
       await pool.query("SELECT * FROM videos WHERE status='approved' ORDER BY created_at DESC")
@@ -115,6 +116,7 @@ export async function getVideo(req: Request, res: Response) {
 
     const result = await pool.query("SELECT * FROM videos WHERE id=$1", [id]);
     if (result.rows.length === 0) {
+      console.warn("[%s] Missing video id=%s", new Date().toISOString(), id);
       return res.status(404).json({ error: "Video not found" });
     }
 

--- a/gateway/server.js
+++ b/gateway/server.js
@@ -66,7 +66,16 @@ function rewriteJsonBody(bodyStr) {
 
 if (BACKEND_TARGET) {
   app.use(`${PUBLIC_BASE_PATH}/api`, createProxyMiddleware({
-    target: BACKEND_TARGET, changeOrigin: true, selfHandleResponse: true,
+    target: BACKEND_TARGET,
+    changeOrigin: true,
+    selfHandleResponse: true,
+    onProxyReq: (proxyReq, req) => {
+      console.log(`[API PROXY] ${req.method} ${req.originalUrl} -> ${BACKEND_TARGET}${req.url}`);
+    },
+    onError: (err, req, res) => {
+      console.error('[API PROXY ERROR]', req.method, req.originalUrl, err.message);
+      res.status(502).end('Bad gateway');
+    },
     onProxyRes: async (proxyRes, req, res) => {
       const ct = proxyRes.headers['content-type'] || '';
       const chunks = [];


### PR DESCRIPTION
## Summary
- log GET /videos requests for debugging
- warn when video id is missing
- log proxied API requests and errors in gateway

## Testing
- `npm test --prefix backend` (fails: Missing script "test")
- `npm run --prefix backend build`
- `node --check gateway/server.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68ab6595c3288320bc934f92966e5df4