### PR TITLE
Add logging for video requests

### DIFF
--- a/backend/src/controllers/video.controller.ts
+++ b/backend/src/controllers/video.controller.ts
@@ -8,6 +8,7 @@ import { pool } from "../config/db.js";
 // загрузка видео
 export async function uploadVideo(req: Request, res: Response) {
   try {
+    console.log("[%s] POST /videos", new Date().toISOString());
     if (!req.file) {
       res.status(400).json({ error: "No video file uploaded" });
       return; // 👈 добавлено для TS
@@ -68,6 +69,7 @@ export async function uploadVideo(req: Request, res: Response) {
       [userId, title, description, key, thumbKey, "pending"]
     );
 
+    console.log("[%s] Uploaded video id=%s", new Date().toISOString(), result.rows[0].id);
     res.json(result.rows[0]);
   } catch (e) {
     console.error("Upload error:", e);
@@ -78,10 +80,13 @@ export async function uploadVideo(req: Request, res: Response) {
 // список видео
 export async function listVideos(req: Request, res: Response) {
   try {
+    console.log("[%s] GET /videos", new Date().toISOString());
     const bucket = process.env.S3_BUCKET!;
+    console.log("Fetching approved videos from DB");
     const videos = (
       await pool.query("SELECT * FROM videos WHERE status='approved' ORDER BY created_at DESC")
     ).rows;
+    console.log("DB returned %d videos", videos.length);
 
     // для каждого видео генерируем Signed URL
     const withUrls = videos.map((v: any) => ({
@@ -100,6 +105,7 @@ export async function listVideos(req: Request, res: Response) {
         : null,
     }));
 
+    console.log("Responding with %d videos", withUrls.length);
     res.json(withUrls);
   } catch (e) {
     console.error("List error:", e);
@@ -111,10 +117,12 @@ export async function listVideos(req: Request, res: Response) {
 export async function getVideo(req: Request, res: Response) {
   try {
     const { id } = req.params;
+    console.log("[%s] GET /videos/%s", new Date().toISOString(), id);
     const bucket = process.env.S3_BUCKET!;
 
     const result = await pool.query("SELECT * FROM videos WHERE id=$1", [id]);
     if (result.rows.length === 0) {
+      console.warn("[%s] Missing video id=%s", new Date().toISOString(), id);
       return res.status(404).json({ error: "Video not found" });
     }
 


### PR DESCRIPTION
## Summary
- log GET /videos requests for debugging
- warn when video id is missing
- log proxied API requests and errors in gateway
- log video uploads and response counts for deeper diagnostics
- report API proxy response statuses

## Testing
- `npm test --prefix backend` (fails: Missing script "test")
- `npm run --prefix backend build`
- `node --check gateway/server.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68ab6595c3288320bc934f92966e5df4