### PR TITLE
Add logging for video requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+dist
 .dist
 uploads
 **/.next

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -23,12 +23,21 @@ export async function register(req: any, res: any) {
 
 export async function login(req: any, res: any) {
   const { email, password } = req.body;
+  console.log("[%s] POST /auth/login %s", new Date().toISOString(), email);
+
   const { rows } = await pool.query('SELECT * FROM users WHERE email=$1', [email]);
   const user = rows[0];
-  if (!user) return res.status(401).json({ error: 'invalid credentials' });
+  if (!user) {
+    console.warn("[%s] Login failed for %s: user not found", new Date().toISOString(), email);
+    return res.status(401).json({ error: 'invalid credentials' });
+  }
   const ok = await bcrypt.compare(password, user.password);
-  if (!ok) return res.status(401).json({ error: 'invalid credentials' });
+  if (!ok) {
+    console.warn("[%s] Login failed for %s: bad password", new Date().toISOString(), email);
+    return res.status(401).json({ error: 'invalid credentials' });
+  }
   const token = jwt.sign({ sub: user.id, role: user.role }, JWT_SECRET, { expiresIn: '7d' });
+  console.log("[%s] Login success for %s", new Date().toISOString(), email);
   res.json({ token, user: { id: user.id, email: user.email, name: user.name, role: user.role } });
 }
 

--- a/backend/src/controllers/video.controller.ts
+++ b/backend/src/controllers/video.controller.ts
@@ -8,6 +8,7 @@ import { pool } from "../config/db.js";
 // загрузка видео
 export async function uploadVideo(req: Request, res: Response) {
   try {
+    console.log("[%s] POST /videos", new Date().toISOString());
     if (!req.file) {
       res.status(400).json({ error: "No video file uploaded" });
       return; // 👈 добавлено для TS
@@ -68,6 +69,7 @@ export async function uploadVideo(req: Request, res: Response) {
       [userId, title, description, key, thumbKey, "pending"]
     );
 
+    console.log("[%s] Uploaded video id=%s", new Date().toISOString(), result.rows[0].id);
     res.json(result.rows[0]);
   } catch (e) {
     console.error("Upload error:", e);
@@ -78,10 +80,13 @@ export async function uploadVideo(req: Request, res: Response) {
 // список видео
 export async function listVideos(req: Request, res: Response) {
   try {
+    console.log("[%s] GET /videos", new Date().toISOString());
     const bucket = process.env.S3_BUCKET!;
+    console.log("Fetching approved videos from DB");
     const videos = (
       await pool.query("SELECT * FROM videos WHERE status='approved' ORDER BY created_at DESC")
     ).rows;
+    console.log("DB returned %d videos", videos.length);
 
     // для каждого видео генерируем Signed URL
     const withUrls = videos.map((v: any) => ({
@@ -100,6 +105,7 @@ export async function listVideos(req: Request, res: Response) {
         : null,
     }));
 
+    console.log("Responding with %d videos", withUrls.length);
     res.json(withUrls);
   } catch (e) {
     console.error("List error:", e);
@@ -111,10 +117,12 @@ export async function listVideos(req: Request, res: Response) {
 export async function getVideo(req: Request, res: Response) {
   try {
     const { id } = req.params;
+    console.log("[%s] GET /videos/%s", new Date().toISOString(), id);
     const bucket = process.env.S3_BUCKET!;
 
     const result = await pool.query("SELECT * FROM videos WHERE id=$1", [id]);
     if (result.rows.length === 0) {
+      console.warn("[%s] Missing video id=%s", new Date().toISOString(), id);
       return res.status(404).json({ error: "Video not found" });
     }
 

--- a/gateway/server.js
+++ b/gateway/server.js
@@ -71,8 +71,9 @@ if (BACKEND_TARGET) {
     selfHandleResponse: true,
     onProxyReq: (proxyReq, req) => {
       console.log(`[API PROXY] ${req.method} ${req.originalUrl} -> ${BACKEND_TARGET}${req.url}`);
-      if (req.body && Object.keys(req.body).length && req.headers['content-type']?.includes('application/json')) {
+      if (req.body && Object.keys(req.body).length) {
         const bodyData = JSON.stringify(req.body);
+        proxyReq.setHeader('Content-Type', req.headers['content-type'] || 'application/json');
         proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
         proxyReq.write(bodyData);
       }

--- a/gateway/server.js
+++ b/gateway/server.js
@@ -66,7 +66,21 @@ function rewriteJsonBody(bodyStr) {
 
 if (BACKEND_TARGET) {
   app.use(`${PUBLIC_BASE_PATH}/api`, createProxyMiddleware({
-    target: BACKEND_TARGET, changeOrigin: true, selfHandleResponse: true,
+    target: BACKEND_TARGET,
+    changeOrigin: true,
+    selfHandleResponse: true,
+    onProxyReq: (proxyReq, req) => {
+      console.log(`[API PROXY] ${req.method} ${req.originalUrl} -> ${BACKEND_TARGET}${req.url}`);
+      if (req.body && Object.keys(req.body).length && req.headers['content-type']?.includes('application/json')) {
+        const bodyData = JSON.stringify(req.body);
+        proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
+        proxyReq.write(bodyData);
+      }
+    },
+    onError: (err, req, res) => {
+      console.error('[API PROXY ERROR]', req.method, req.originalUrl, err.message);
+      res.status(502).end('Bad gateway');
+    },
     onProxyRes: async (proxyRes, req, res) => {
       const ct = proxyRes.headers['content-type'] || '';
       const chunks = [];
@@ -88,6 +102,7 @@ if (BACKEND_TARGET) {
         }
         res.statusCode = proxyRes.statusCode || 200;
         res.end(body);
+        console.log(`[API PROXY RES] ${req.method} ${req.originalUrl} <- ${proxyRes.statusCode}`);
       });
     },
     pathRewrite: pathStr => pathStr.replace(new RegExp(`^${PUBLIC_BASE_PATH}/api`), ''),

--- a/gateway/server.js
+++ b/gateway/server.js
@@ -71,7 +71,11 @@ if (BACKEND_TARGET) {
     selfHandleResponse: true,
     onProxyReq: (proxyReq, req) => {
       console.log(`[API PROXY] ${req.method} ${req.originalUrl} -> ${BACKEND_TARGET}${req.url}`);
-      if (req.body && Object.keys(req.body).length) {
+      if (
+        req.body &&
+        Object.keys(req.body).length &&
+        req.headers['content-type']?.includes('application/json')
+      ) {
         const bodyData = JSON.stringify(req.body);
         proxyReq.setHeader('Content-Type', req.headers['content-type'] || 'application/json');
         proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));

--- a/gateway/server.js
+++ b/gateway/server.js
@@ -65,53 +65,50 @@ function rewriteJsonBody(bodyStr) {
 }
 
 if (BACKEND_TARGET) {
-  app.use(`${PUBLIC_BASE_PATH}/api`, createProxyMiddleware({
-    target: BACKEND_TARGET,
-    changeOrigin: true,
-    selfHandleResponse: true,
-    onProxyReq: (proxyReq, req) => {
-      console.log(`[API PROXY] ${req.method} ${req.originalUrl} -> ${BACKEND_TARGET}${req.url}`);
-      if (
-        req.body &&
-        Object.keys(req.body).length &&
-        req.headers['content-type']?.includes('application/json')
-      ) {
-        const bodyData = JSON.stringify(req.body);
-        proxyReq.setHeader('Content-Type', req.headers['content-type'] || 'application/json');
-        proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
-        proxyReq.write(bodyData);
-      }
-    },
-    onError: (err, req, res) => {
-      console.error('[API PROXY ERROR]', req.method, req.originalUrl, err.message);
-      res.status(502).end('Bad gateway');
-    },
-    onProxyRes: async (proxyRes, req, res) => {
-      const ct = proxyRes.headers['content-type'] || '';
-      const chunks = [];
-      proxyRes.on('data', c => chunks.push(c));
-      proxyRes.on('end', () => {
-        const buf = Buffer.concat(chunks);
-        let body = buf.toString('utf-8');
-        if (ct.includes('application/json')) {
-          body = rewriteJsonBody(body);
-          res.setHeader('content-type', 'application/json; charset=utf-8');
-        } else {
-          if (process.env.BACKEND_TARGET) body = body.split(BACKEND_TARGET).join('/api');
-          if (process.env.MINIO_TARGET) body = body.split(MINIO_TARGET).join('/proxy-file?u=' + encodeURIComponent(process.env.MINIO_TARGET));
-          if (ct) res.setHeader('content-type', ct);
+  app.use(
+    `${PUBLIC_BASE_PATH}/api`,
+    createProxyMiddleware({
+      target: BACKEND_TARGET, changeOrigin: true, selfHandleResponse: true,
+      onProxyReq: (proxyReq, req) => {
+        console.log(`[API PROXY] ${req.method} ${req.originalUrl} -> ${BACKEND_TARGET}${req.url}`);
+        if (req.body && Object.keys(req.body).length && req.headers['content-type']?.includes('application/json')) {
+          const bodyData = JSON.stringify(req.body);
+          proxyReq.setHeader('Content-Type', req.headers['content-type'] || 'application/json');
+          proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
+          proxyReq.write(bodyData);
         }
-        for (const [k,v] of Object.entries(proxyRes.headers)) {
-          if (k.toLowerCase()==='content-length' || k.toLowerCase()==='content-type') continue;
-          res.setHeader(k, v);
-        }
-        res.statusCode = proxyRes.statusCode || 200;
-        res.end(body);
-        console.log(`[API PROXY RES] ${req.method} ${req.originalUrl} <- ${proxyRes.statusCode}`);
-      });
-    },
-    pathRewrite: pathStr => pathStr.replace(new RegExp(`^${PUBLIC_BASE_PATH}/api`), ''),
-  }));
+      },
+      onError: (err, req, res) => {
+        console.error('[API PROXY ERROR]', req.method, req.originalUrl, err.message);
+        res.status(502).end('Bad gateway');
+      },
+      onProxyRes: async (proxyRes, req, res) => {
+        const ct = proxyRes.headers['content-type'] || '';
+        const chunks = [];
+        proxyRes.on('data', c => chunks.push(c));
+        proxyRes.on('end', () => {
+          const buf = Buffer.concat(chunks);
+          let body = buf.toString('utf-8');
+          if (ct.includes('application/json')) {
+            body = rewriteJsonBody(body);
+            res.setHeader('content-type', 'application/json; charset=utf-8');
+          } else {
+            if (process.env.BACKEND_TARGET) body = body.split(BACKEND_TARGET).join('/api');
+            if (process.env.MINIO_TARGET) body = body.split(MINIO_TARGET).join('/proxy-file?u=' + encodeURIComponent(process.env.MINIO_TARGET));
+            if (ct) res.setHeader('content-type', ct);
+          }
+          for (const [k, v] of Object.entries(proxyRes.headers)) {
+            if (k.toLowerCase() === 'content-length' || k.toLowerCase() === 'content-type') continue;
+            res.setHeader(k, v);
+          }
+          res.statusCode = proxyRes.statusCode || 200;
+          res.end(body);
+          console.log(`[API PROXY RES] ${req.method} ${req.originalUrl} <- ${proxyRes.statusCode}`);
+        });
+      },
+      pathRewrite: pathStr => pathStr.replace(new RegExp(`^${PUBLIC_BASE_PATH}/api`), ''),
+    })
+  );
 }
 
 app.get(`${PUBLIC_BASE_PATH}/files/:bucket/*`, async (req, res) => {


### PR DESCRIPTION
## Summary
- log GET /videos requests for debugging
- warn when video id is missing
- log proxied API requests and errors in gateway
- log video uploads and response counts for deeper diagnostics
- report API proxy response statuses
- log login attempts and outcomes
- forward JSON request bodies through gateway

## Testing
- `npm test --prefix backend` (fails: Missing script "test")
- `npm run --prefix backend build`
- `node --check gateway/server.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68ab6595c3288320bc934f92966e5df4