### PR TITLE
feat: add ReelsUp logo

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,6 +4,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <title>Video Marketplace</title>
   </head>
   <body>

--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="24" cy="40" r="20" fill="#2fc3c9"/>
+  <circle cx="16" cy="32" r="3" fill="#ffffff"/>
+  <circle cx="24" cy="48" r="3" fill="#ffffff"/>
+  <circle cx="32" cy="32" r="3" fill="#ffffff"/>
+  <path d="M48 44V24h-8l8-16 8 16h-8v20z" fill="#ffffff" stroke="#0b2239" stroke-width="2" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -3,8 +3,8 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import App from './App';
 
-test('renders brand name', () => {
+test('renders logo', () => {
   render(<App />);
-  const el = screen.getByText(/VideoMarket/i);
+  const el = screen.getByAltText(/ReelsUp/i);
   expect(el).toBeInTheDocument();
 });

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -8,7 +8,7 @@ export default function NavBar({ darkMode, toggleTheme }) {
   const nav = useNavigate();
   return (
     <div className="navbar">
-      <div className="brand"><Link to="/"><strong>VideoMarket</strong></Link></div>
+      <div className="brand"><Link to="/"><img src="/logo.svg" alt="ReelsUp" /></Link></div>
       <div className="links">
         <button onClick={toggleTheme} title="Переключить тему">{darkMode ? '☀️' : '🌙'}</button>
         {user ? (<>


### PR DESCRIPTION
## Summary
- add film reel logo with upward arrow
- use new logo as favicon and navbar brand
- update test to check for logo presence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abae71d8288320a28cbf623ae8397a