### PR TITLE
feat: refresh feed with gradient style

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,6 +5,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet" />
+    <script src="https://cdn.tailwindcss.com"></script>
     <title>Video Marketplace</title>
   </head>
   <body>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,20 +1,22 @@
 
 .light {
-  --bg-color: #ffffff;
-  --text-color: #0b2239;
-  --accent-color: #2fc3c9; /* бирюзово-голубой */
-  --card-bg: #f6fbff;
-  --border-color: #d6e6f2;
+  --bg-color: #fdfdfe;
+  --text-color: #1e293b;
+  --accent-color: #ff7aa2;
+  --card-bg: #ffffff;
+  --border-color: #e2e8f0;
+  --bg-gradient: linear-gradient(135deg, #fbc2eb 0%, #a6c1ee 100%);
 }
 .dark {
   --bg-color: #0b0f14;
   --text-color: #e0f0ff;
-  --accent-color: #3dd9df;
+  --accent-color: #ff86b3;
   --card-bg: #151a22;
   --border-color: #263141;
+  --bg-gradient: linear-gradient(135deg, #1e3a8a 0%, #1e40af 100%);
 }
-html, body { margin: 0; padding: 0; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; }
-.app-container { background-color: var(--bg-color); color: var(--text-color); min-height: 100vh; }
+html, body { margin: 0; padding: 0; font-family: 'Poppins', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; }
+.app-container { background: var(--bg-gradient); color: var(--text-color); min-height: 100vh; }
 a { color: var(--accent-color); text-decoration: none; }
 a:hover { text-decoration: underline; }
 .navbar {
@@ -28,20 +30,48 @@ a:hover { text-decoration: underline; }
   margin-right: 12px;
 }
 .brand { font-weight: 800; letter-spacing: .4px; }
+.section-header {
+  text-align: center;
+  padding: 40px 0 20px;
+  font-size: 2rem;
+  font-weight: 700;
+}
 .feed {
-  display: grid; grid-template-columns: repeat(auto-fill, minmax(480px, 1fr)); gap: 16px;
-  padding: 16px; max-width: 1100px; margin: 0 auto;
+  column-width: 320px;
+  column-gap: 16px;
+  padding: 16px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+@media (max-width: 768px) {
+  .feed {
+    column-width: 100%;
+  }
 }
 .video-card {
   border: 1px solid var(--border-color);
-  border-radius: 14px;
+  border-radius: 16px;
   background: var(--card-bg);
   overflow: hidden;
-  box-shadow: 0 1px 1px rgba(0,0,0,0.04);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+  margin: 0 0 16px;
+  transition: transform .2s, box-shadow .2s;
 }
-.video-card .content { padding: 10px 12px; }
+.video-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+}
+.video-card .content { padding: 12px 14px; }
 .video-card h3 { margin: 6px 0; font-size: 1.05rem; }
 .video-card small { color: #718096; }
+.badge {
+  background: var(--accent-color);
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  margin-left: 6px;
+}
 /* thumbnail handled via .thumb-wrap */
 input, select, textarea, button {
   background: var(--bg-color); color: var(--text-color);

--- a/frontend/src/components/VideoCard.js
+++ b/frontend/src/components/VideoCard.js
@@ -19,8 +19,14 @@ export default function VideoCard({ video }) {
       </Link>
       <div className="content">
         <h3><Link to={`/video/${video.id}`}>{video.title}</Link></h3>
-        <small>Автор: {video.user_name} {video.category_name && (` | Категория: ${video.category_name}`)}</small><br/>
-        <small>Лайков: {video.likes_count} | Комментариев: {video.comments_count}{!video.is_approved && <span style={{color:'orange'}}> (на модерации)</span>}</small>
+        <small>
+          Автор: {video.user_name}
+          {video.category_name && <span className="badge">{video.category_name}</span>}
+        </small><br/>
+        <small>
+          Лайков: {video.likes_count} | Комментариев: {video.comments_count}
+          {!video.is_approved && <span className="badge" style={{background:'orange'}}>Модерация</span>}
+        </small>
       </div>
     </div>
   );

--- a/frontend/src/components/VideoSkeleton.js
+++ b/frontend/src/components/VideoSkeleton.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function VideoSkeleton() {
+  return (
+    <div className="video-card animate-pulse">
+      <div className="thumb-wrap bg-gray-300 dark:bg-gray-700"></div>
+      <div className="content">
+        <div className="h-4 bg-gray-300 dark:bg-gray-700 rounded w-3/4 mb-2"></div>
+        <div className="h-3 bg-gray-300 dark:bg-gray-700 rounded w-1/2"></div>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/Feed.js
+++ b/frontend/src/pages/Feed.js
@@ -2,9 +2,11 @@
 import React, { useEffect, useState } from 'react';
 import { apiGet } from '../api';
 import VideoCard from '../components/VideoCard';
+import VideoSkeleton from '../components/VideoSkeleton';
 
 export default function Feed() {
   const [videos, setVideos] = useState([]);
+  const [loading, setLoading] = useState(true);
   const [q, setQ] = useState('');
   const [category, setCategory] = useState('');
   const [categories, setCategories] = useState([]);
@@ -15,18 +17,22 @@ export default function Feed() {
   }, []);
 
   const load = (qq='', cc='') => {
+    setLoading(true);
     let url = '/api/videos';
     const params = [];
     if (qq) params.push('q='+encodeURIComponent(qq));
     if (cc) params.push('category='+cc);
     if (params.length) url += '?' + params.join('&');
-    apiGet(url).then(setVideos).catch(()=>{});
+    apiGet(url)
+      .then(data => { setVideos(data); setLoading(false); })
+      .catch(() => setLoading(false));
   };
 
   const search = (e) => { e.preventDefault(); load(q, category); };
 
   return (
     <div>
+      <h1 className="section-header">Лента ReelsUp</h1>
       <form onSubmit={search} style={{ textAlign:'center', marginTop:10 }}>
         <input placeholder="Поиск..." value={q} onChange={e=>setQ(e.target.value)} />
         <select value={category} onChange={e=>setCategory(e.target.value)} style={{ marginLeft: 6 }}>
@@ -36,7 +42,9 @@ export default function Feed() {
         <button style={{ marginLeft: 6 }}>Найти</button>
       </form>
       <div className="feed">
-        {videos.map(v => <VideoCard key={v.id} video={v} />)}
+        {loading
+          ? Array.from({ length: 6 }).map((_, i) => <VideoSkeleton key={i} />)
+          : videos.map(v => <VideoCard key={v.id} video={v} />)}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- integrate Tailwind via CDN and Poppins font
- redesign feed grid with pastel gradients and card hovers
- add skeleton loading cards

## Testing
- `npm test`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68abb3c728bc8320ab40246557527d41